### PR TITLE
Implement plugins

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,11 +1,17 @@
 # TODO
 
 - plugins
-    - steps: imports, setup, test, confirm, execue, clean...
+    - loggin
+    - Download plugin tarbal
+    - Copy plugin folder
 - remove all no-core scripts
     - change distro to repository (archlinux -> pacman)
 - Execution list (list of scripts to execute)
-- Import sh files
+- steps
+    - verify instalation is ok
+    - clean after install
+- Fix paths
+- Tests
 - doc
 
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,21 @@
 # TODO
 
-- doc!
-- install and configure dotfiles via git or local
-- clone git projects
-- import sh files
-- list of scripts to execute
-- configure distro (locale, language, etc)
+- plugins
+    - steps: imports, setup, test, confirm, execue, clean...
+- remove all no-core scripts
+    - change distro to repository (archlinux -> pacman)
+- Execution list (list of scripts to execute)
+- Import sh files
+- doc
+
+
+# Plugins
+
+- dotfiles
+- git
+- pip
+- npm
+- gem
+- pacman
+- apt-get
+- yum

--- a/pdc/install.sh
+++ b/pdc/install.sh
@@ -2,29 +2,32 @@
 
 printf "\n == Welcome to Personal Distro Configurator! == \n\n"
 
-# 0.init
+# Initial Settings
 printf "Initial settings..."
 set -e
 cd $(dirname $(readlink -f $0))
 printf " ok\n"
 
-# 1.imports
+# Imports
 printf "Imports..."
 source sh/init/imports.sh
 printf " ok\n"
 
-# 2.Setup
+# Plugins
+pdc_get_plugins
+
+# Setup
 pdc_setup
 
-# 3.Test
+# TODO: Test
 
-# 4.confirm
+# Confirm
 printf "\nStarting logs\n"
 pdc_confirm
 
-# 5.Execute
+# Execute
 pdc_execute
 
-# 6.Clean
+# TODO: Clean
 
 log_info "Installation done with success!" && exit 0

--- a/pdc/settings.yml
+++ b/pdc/settings.yml
@@ -10,6 +10,7 @@ settings:
     install: "${HOME}/.personal-distro-configurator/"
     log: "${HOME}/.personal-distro-configurator/log/"
     tmp: "${HOME}/.personal-distro-configurator/tmp/"
+    plugins: "../plugins/"
   file:
     log: "install.log"
   yaml_files:

--- a/pdc/settings.yml
+++ b/pdc/settings.yml
@@ -1,5 +1,5 @@
 settings:
-  update_distro: true
+  # update_distro: true --Must be moved to a plugin
   verbose: false
   system:
     distro: ""
@@ -14,11 +14,14 @@ settings:
     log: "install.log"
   yaml_files:
     -
-  dependencies:
+  plugins:
     -
-  pip:
-    -
-  gem:
-    -
-  npm:
-    -
+# These scripts must be moved to a plugin
+#  dependencies:
+#    -
+#  pip:
+#    -
+#  gem:
+#    -
+#  npm:
+#    -

--- a/pdc/sh/distro/archlinux.sh
+++ b/pdc/sh/distro/archlinux.sh
@@ -1,19 +1,21 @@
 #!/bin/bash
 
-function distro_update() {
-    sudo pacman -Syu
-}
+## TODO: Move to a plugin
 
-function distro_install_dependencies() {
-    eval "sudo pacman -S ${settings_dependencies[*]}"
-}
+#function distro_update() {
+#    sudo pacman -Syu
+#}
 
-function distro_install() {
-    local dependencie=$1
-    sudo pacman -S "$dependencie"
-}
+#function distro_install_dependencies() {
+#    eval "sudo pacman -S ${settings_dependencies[*]}"
+#}
 
-function distro_remove() {
-    local dependencie=$1
-    sudo pacman -Rc "$dependencie"
-}
+#function distro_install() {
+#    local dependencie=$1
+#    sudo pacman -S "$dependencie"
+#}
+
+#function distro_remove() {
+#    local dependencie=$1
+#    sudo pacman -Rc "$dependencie"
+#}

--- a/pdc/sh/init/confirm.sh
+++ b/pdc/sh/init/confirm.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 function pdc_confirm() {
+    # Header
     log_info && log_info "--------------------------------------- --"
     log_info && log_info "Personal Distro Configurator install at $(date)"
 
@@ -22,6 +23,11 @@ function pdc_confirm() {
 
     for yaml_file in $settings_yaml_files; do
         log_info "$yaml_file"
+    done
+
+    # Plugins
+    for i in ${!settings_plugin_steps_confirm[*]}; do
+        eval ${settings_plugin_steps_confirm[i]}
     done
 
     ## TODO: Move to plugin {

--- a/pdc/sh/init/confirm.sh
+++ b/pdc/sh/init/confirm.sh
@@ -24,14 +24,16 @@ function pdc_confirm() {
         log_info "$yaml_file"
     done
 
+    ## TODO: Move to plugin {
     # Repository
-    [[ "$settings_update_distro" == "true" ]] && log_info "# Distro will be updated" && log_info
-    [[ "$settings_dependencies" != "" ]] && log_info "# Dependencies: ${settings_dependencies[*]}" && log_info
+    #[[ "$settings_update_distro" == "true" ]] && log_info "# Distro will be updated" && log_info
+    #[[ "$settings_dependencies" != "" ]] && log_info "# Dependencies: ${settings_dependencies[*]}" && log_info
 
     # Installs
-    [[ "$settings_pip" != "" ]] && log_info "# PIP: ${settings_pip[*]}" && log_info
-    [[ "$settings_gem" != "" ]] && log_info "# GEM: ${settings_gem[*]}" && log_info
-    [[ "$settings_npm" != "" ]] && log_info "# NPM: ${settings_npm[*]}" && log_info
+    #[[ "$settings_pip" != "" ]] && log_info "# PIP: ${settings_pip[*]}" && log_info
+    #[[ "$settings_gem" != "" ]] && log_info "# GEM: ${settings_gem[*]}" && log_info
+    #[[ "$settings_npm" != "" ]] && log_info "# NPM: ${settings_npm[*]}" && log_info
+    ## --}
 
     # Confirm
     log_info "Confirm? [Y/n]" && read -r option

--- a/pdc/sh/init/execute.sh
+++ b/pdc/sh/init/execute.sh
@@ -1,40 +1,45 @@
 #!/bin/bash
 
 function pdc_execute() {
+
+    ## TODO: Move to plugin {
+
     # Update distro
-    if [[ "$settings_update_distro" == "true" ]]; then
-        log_info "Updating distro..." && log_info
-        distro_update
-        log_info "Distro updated!" && log_info
-    fi
+    #if [[ "$settings_update_distro" == "true" ]]; then
+    #    log_info "Updating distro..." && log_info
+    #    distro_update
+    #    log_info "Distro updated!" && log_info
+    #fi
 
     # Install all distro dependencies
-    if [[ "$settings_dependencies" != "" ]]; then
-        log_info "Install dependencies..." && log_info
-        distro_install_dependencies
-        log_info "Dependencies installed with success!" && log_info
-    fi
+    #if [[ "$settings_dependencies" != "" ]]; then
+    #    log_info "Install dependencies..." && log_info
+    #    distro_install_dependencies
+    #    log_info "Dependencies installed with success!" && log_info
+    #fi
 
     # Install pip
-    if [[ "$settings_pip" != "" ]]; then
-        log_info "Running pip install..." && log_info
-        pip_install
-        log_info "Pip install executed with success!" && log_info
-    fi
+    #if [[ "$settings_pip" != "" ]]; then
+    #    log_info "Running pip install..." && log_info
+    #    pip_install
+    #    log_info "Pip install executed with success!" && log_info
+    #fi
 
     # Install gem
-    if [[ "$settings_gem" != "" ]]; then
-        log_info "Running gem install..." && log_info
-        gem_install
-        log_info "Gem install executed with success!" && log_info
-    fi
+    #if [[ "$settings_gem" != "" ]]; then
+    #    log_info "Running gem install..." && log_info
+    #    gem_install
+    #    log_info "Gem install executed with success!" && log_info
+    #fi
 
     # Install npm
-    if [[ "$settings_npm" != "" ]]; then
-        log_info "Running npm install..." && log_info
-        npm_install
-        log_info "Npm install executed with success!" && log_info
-    fi
+    #if [[ "$settings_npm" != "" ]]; then
+    #    log_info "Running npm install..." && log_info
+    #    npm_install
+    #    log_info "Npm install executed with success!" && log_info
+    #fi
+
+    # --}
 
     log_info "Executions done!" && log_info
 }

--- a/pdc/sh/init/execute.sh
+++ b/pdc/sh/init/execute.sh
@@ -2,6 +2,11 @@
 
 function pdc_execute() {
 
+    # Plugins
+    for i in ${!settings_plugin_steps_execute[*]}; do
+        eval ${settings_plugin_steps_execute[i]}
+    done
+
     ## TODO: Move to plugin {
 
     # Update distro

--- a/pdc/sh/init/imports.sh
+++ b/pdc/sh/init/imports.sh
@@ -11,10 +11,12 @@ source sh/init/setup.sh
 source sh/init/confirm.sh
 source sh/init/execute.sh
 
+## TODO: Move to plugin {
 # Distro
-source sh/distro/archlinux.sh
+#source sh/distro/archlinux.sh
 
 # Installers
-source sh/installers/pip.sh
-source sh/installers/gem.sh
-source sh/installers/npm.sh
+#source sh/installers/pip.sh
+#source sh/installers/gem.sh
+#source sh/installers/npm.sh
+## --}

--- a/pdc/sh/init/imports.sh
+++ b/pdc/sh/init/imports.sh
@@ -7,6 +7,7 @@ source sh/utils/log.sh
 source sh/utils/lock.sh
 
 # Init
+source sh/init/plugins.sh
 source sh/init/setup.sh
 source sh/init/confirm.sh
 source sh/init/execute.sh

--- a/pdc/sh/init/plugins.sh
+++ b/pdc/sh/init/plugins.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+function pdc_get_plugins() {
+
+    for i in ${!settings_plugins[*]}; do
+        local plugin=${settings_plugins[i]}
+
+        case $plugin in
+            http://*) pdc_clone_plugin "$plugin" ;; # Git HTTP
+            https://*) pdc_clone_plugin "$plugin" ;; # Git HTTPS
+            git@*) pdc_clone_plugin "$plugin" ;; # Git SSH
+            path::*) pdc_copy_plugin $( echo "$plugin" | sed 's/path:://' ) ;; # Directory Local
+            tarbal::*) pdc_download_plugin $( echo "$plugin" | sed 's/tarbal:://' ) ;; # Tarbal Download
+            *) pdc_clone_plugin "https://github.com/${plugin}.git" ;; # Github
+        esac
+    done
+}
+
+# Getting plugins via...
+# ----------------------
+
+function pdc_clone_plugin() {
+    # Git Clone http and ssh
+    local git_project_url=$1
+    cd "$settings_path_plugins" && { git clone "$git_project_url"; cd -; }
+}
+
+function pdc_download_plugin() {
+    # Download compressed plugin (tarbal, zip, rar, etc)
+    # TODO
+    return
+}
+
+function pdc_copy_plugin() {
+    # Copy plugin folder from some directory
+    # TODO
+    return
+}

--- a/pdc/sh/init/setup.sh
+++ b/pdc/sh/init/setup.sh
@@ -4,20 +4,53 @@ function pdc_setup() {
     printf "Setup installer...\n"
 
     pdc_lock_file
+    pdc_create_variables
+    pdc_plugin_import
+    pdc_create_paths
+    pdc_plugin_setup
 
+    printf "Setup done!\n"
+}
+
+function pdc_plugin_setup() {
+    for i in ${!settings_plugin_steps_setup[*]}; do
+        eval ${settings_plugin_steps_setup[i]}
+    done
+}
+
+function pdc_plugin_import() {
+    for i in ${!settings_plugin_steps_import[*]}; do
+        source ${settings_plugin_steps_import[i]}
+    done
+}
+
+function pdc_create_variables() {
+    # Default .yml
     pdc_create_variables "settings.yml"
 
+    # User .yml
+    [ -f "../pdc.yml" ] && pdc_create_variables "../pdc.yml"
+
+    # Plugins .yml
+    [ -d "../plugins" ] &&
+    for entry in ../plugins/*; do
+
+        [ -d "$entry" ] && [ "$(ls "$entry")" ] &&
+        for e in $entry/*; do
+            [ -f "${e}/plugin.yml" ] && pdc_create_variables "${e}/plugin.yml"
+        done
+    done
+
+    # Additional .yml
     for yaml_file in $settings_yaml_files; do
         log_verbose "Add ${yaml_file} settings file" && log_verbose
         pdc_create_variables "$yaml_file"
     done
+}
 
-    [ -f "../pdc.yml" ] && pdc_create_variables "../pdc.yml"
-
+function pdc_create_paths() {
     _create_if_not_exists "$settings_path_install"
     _create_if_not_exists "$settings_path_log"
-
-    printf "Setup done!\n"
 }
 
 function _create_if_not_exists() {

--- a/pdc/sh/installers/gem.sh
+++ b/pdc/sh/installers/gem.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-function gem_install() {
-    pdc_test_command "gem"
-    gem install "${settings_gem[*]}"
-}
+## TODO: Move to a plugin
+
+#function gem_install() {
+#    pdc_test_command "gem"
+#    gem install "${settings_gem[*]}"
+#}

--- a/pdc/sh/installers/npm.sh
+++ b/pdc/sh/installers/npm.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-function npm_install() {
-    pdc_test_command "npm"
-    sudo npm install -g "${settings_npm[*]}"
-}
+## TODO: Move to a plugin
+
+#function npm_install() {
+#    pdc_test_command "npm"
+#    sudo npm install -g "${settings_npm[*]}"
+#}

--- a/pdc/sh/installers/pip.sh
+++ b/pdc/sh/installers/pip.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-function pip_install() {
-    pdc_test_command "pip"
-    sudo pip install "${settings_pip[*]}"
-}
+## TODO: Move to a plugin
+
+#function pip_install() {
+#    pdc_test_command "pip"
+#    sudo pip install "${settings_pip[*]}"
+#}

--- a/samples/pdc.yml
+++ b/samples/pdc.yml
@@ -3,21 +3,9 @@ settings:
     distro: "archlinux"
     arch: "x86_64"
     wm: "i3"
-  dependencies:
-    - git
-    - ruby
-    - python
-    - python-pip
-    - npm
-    - firefox
-    - termite
-    - zsh
-    - zip
-  pip:
-    - pep8
-  gem:
-    - carrierwave
-    - kaminari
-  npm:
-    - bower
-    - grunt
+  plugins:
+    - user/project
+    - https://git.com/user/project.git
+    - git@git.com:user/project.git
+    - path:://path/to/plugin
+    - tarball::endpoint/to/tarbal.tar

--- a/samples/plugin-sample/plugin.yml
+++ b/samples/plugin-sample/plugin.yml
@@ -1,0 +1,11 @@
+settings:
+  plugin:
+    steps:
+      import:
+        -
+      setup:
+        -
+      confirm:
+        -
+      execute:
+        -


### PR DESCRIPTION
Leave only core on PDC and move the rest on plugins. It possibility a community help too, and separate what is really needed on PDC script and what is opcional, based on what user want to do.

Currently, only git clone plugins are viable. Nothing is logging and every non-core things are commented.

Committing this way to continue working on move non-core things to plugins and refactoring what is needed.