### PR TITLE
Implement user executions

### DIFF
--- a/pdc/settings.yml
+++ b/pdc/settings.yml
@@ -19,6 +19,8 @@ settings:
     -
   plugins:
     -
+  execute:
+    -
 # These scripts must be moved to a plugin
 #  dependencies:
 #    -

--- a/pdc/sh/init/confirm.sh
+++ b/pdc/sh/init/confirm.sh
@@ -25,6 +25,10 @@ function pdc_confirm() {
         log_info "$yaml_file"
     done
 
+    # Executions
+    [ ! ${#settings_execute[@]} -eq 0 ] &&
+    log_verbose "# User execute lines to run: ${#settings_execute[@]}" && log_verbose
+
     # Plugins
     for i in ${!settings_plugin_steps_confirm[*]}; do
         eval ${settings_plugin_steps_confirm[i]}

--- a/pdc/sh/init/execute.sh
+++ b/pdc/sh/init/execute.sh
@@ -7,6 +7,13 @@ function pdc_execute() {
         eval ${settings_plugin_steps_execute[i]}
     done
 
+    # User Executions
+    log_info "Running user executions..." && log_info
+    for i in ${!settings_execute[*]}; do
+        eval ${settings_execute[i]}
+    done
+    log_info && log_info "User executions done!" && log_info
+
     ## TODO: Move to plugin {
 
     # Update distro


### PR DESCRIPTION
Now user can list scripts to run. What is informed is a bash script.
With it, is possible to call a python, ruby, java, zsh and any others
scripts to run.

These executions will run AFTER plugins executions.