### PR TITLE
Add plugin version, using git branch or tag

### DIFF
--- a/changelogs/unreleased/33-plugin-git-branch.yml
+++ b/changelogs/unreleased/33-plugin-git-branch.yml
@@ -1,0 +1,2 @@
+title: Add plugin version by git branch or tag
+pull_request: 33

--- a/pdc/sh/init/plugins.sh
+++ b/pdc/sh/init/plugins.sh
@@ -6,12 +6,12 @@ function pdcdef_get_plugins() {
         local plugin=${pdcyml_plugins_get[i]}
 
         case $plugin in
-            http://*) pdcdef_clone_plugin "$plugin" ;; # Git HTTP
-            https://*) pdcdef_clone_plugin "$plugin" ;; # Git HTTPS
+            http://*) pdcdef_clone_plugin "$(echo ${plugin} | cut -d ':' -f1)" "$(echo ${plugin} | cut -d ':' -f2)" ;; # Git HTTP
+            https://*) pdcdef_clone_plugin "$(echo ${plugin} | cut -d ':' -f1)" "$(echo ${plugin} | cut -d ':' -f2)" ;; # Git HTTPS
             git@*) pdcdef_clone_plugin "$plugin" ;; # Git SSH
             path::*) pdcdef_copy_plugin $( echo "$plugin" | sed 's/path:://' ) ;; # Directory Local
             tarbal::*) pdcdef_download_plugin $( echo "$plugin" | sed 's/tarbal:://' ) ;; # Tarbal Download
-            *) pdcdef_clone_plugin "https://github.com/${plugin}.git" ;; # Github
+            *) pdcdef_clone_plugin "https://github.com/$(echo ${plugin} | cut -d ':' -f1).git" "$(echo ${plugin} | cut -d ':' -f2)" ;; # Github
         esac
     done
 }
@@ -22,7 +22,10 @@ function pdcdef_get_plugins() {
 function pdcdef_clone_plugin() {
     # Git Clone http and ssh
     local git_project_url=$1
-    cd "$pdcyml_settings_path_plugins" && { log_verbose "Clone $git_project_url" && log_verbose; git clone "$git_project_url"; cd -; }
+    local branch=$([[ -n "${pdcyml_system_wm/[ ]*\n/}" ]] && echo "--branch $2")
+    local cmd="git clone ${git_project_url} ${branch} --depth 1"
+
+    cd "$pdcyml_settings_path_plugins" && $cmd; cd -;
 }
 
 function pdcdef_download_plugin() {


### PR DESCRIPTION
When git clone a project, now passing ":<branch>" or ":<tag>" on sufix will clone this branch or tag, such as "personal-distro-configurator/pdc-pip-plugin:v0.0.1".