### PR TITLE
Implement execute list by executors functions

### DIFF
--- a/changelogs/unreleased/34-executors.yml
+++ b/changelogs/unreleased/34-executors.yml
@@ -1,0 +1,2 @@
+title: Add executor for execute step
+pull_request: 34

--- a/changelogs/unreleased/34-remove-plugins-execute.yaml
+++ b/changelogs/unreleased/34-remove-plugins-execute.yaml
@@ -1,0 +1,2 @@
+title: Remove plugins execute list from main execute step
+pull_request: 34

--- a/changelogs/unreleased/34-remove-pre-plugin-execute.yaml
+++ b/changelogs/unreleased/34-remove-pre-plugin-execute.yaml
@@ -1,0 +1,2 @@
+title: Remove plugin pre-execute step
+pull_request: 34

--- a/pdc/settings.yml
+++ b/pdc/settings.yml
@@ -9,6 +9,21 @@ settings:
     plugins: ${pdcyml_settings_path_install}/plugins
   file:
     log: install.log
+  executors:
+    -
+      command: shell
+      function: pdcdef_execute_shell
+    -
+      command: sh
+      function: pdcdef_execute_sh
+    -
+      command: bash
+      function: pdcdef_execute_bash
+    -
+      command: plugin
+      function: pdcdef_execute_plugin
+  exclude:
+    - plugins_steps_execute
 
 system:
   distro:
@@ -24,8 +39,6 @@ execute:
 
 plugins:
   get:
-    -
-  pre_execute:
     -
   steps:
     import:

--- a/pdc/sh/init/execute.sh
+++ b/pdc/sh/init/execute.sh
@@ -2,27 +2,55 @@
 
 function pdcdef_execute() {
 
-    # Pre-Execute Plugins
-    log_info "Running pre-execute plugins..." && log_info
-    for i in ${!pdcyml_plugins_pre_execute[*]}; do
-        eval ${pdcyml_plugins_pre_execute[i]}
-    done
-    log_info && log_info "Pre-execute plugins done!" && log_info
+    # Start
+    log_info "Starting executions..." && log_info
 
-    # Plugins
-    log_info "Running plugins execute step..." && log_info
-    for i in ${!pdcyml_plugins_steps_execute[*]}; do
-        eval ${pdcyml_plugins_steps_execute[i]}
+    # Run every execute command
+    for execution in "${pdcyml_execute[@]}"; do
+        # Find executor for execute command
+        for i in ${!pdcyml_settings_executors__command[*]}; do
+            # test if executor is what was informed
+            [ "${pdcyml_settings_executors__command[$i]}" = "$(echo $execution | cut -d ' ' -f1)" ] &&
+            # if is, call function for this command, passing all arguments informed
+            "${pdcyml_settings_executors__function[$i]}" "${execution#${pdcyml_settings_executors__command[$i]} }"
+        done
     done
-    log_info && log_info "Plugins executions done!" && log_info
-
-    # User Executions
-    log_info "Running user executions..." && log_info
-    for i in ${!pdcyml_execute[*]}; do
-        eval ${pdcyml_execute[i]}
-    done
-    log_info && log_info "User executions done!" && log_info
 
     # Done
     log_info "Executions done!" && log_info
+}
+
+# ---------
+# Executors
+# ---------
+
+# Run a specific command
+function pdcdef_execute_shell() {
+    local cmd=$1
+    eval "$cmd"
+}
+
+# Run a sh file, if it as arguments, is informed too
+function pdcdef_execute_sh() {
+    local sh_file=$1
+    sh "$sh_file"
+}
+
+# Run a bash file, if it as arguments, is informed too
+function pdcdef_execute_bash() {
+    local bash_file=$1
+    bash "$bash_file"
+}
+
+# Run execute list from a plugin
+function pdcdef_execute_plugin() {
+    local plugin=$1
+
+    local cmd
+
+    cmd="$(pdcdef_load_settings "${pdcyml_settings_path_plugins}/pdc-${plugin}-plugin/plugin.yml" pdcyml_plugins_steps_execute)"
+
+    for c in ${cmd[*]}; do
+        eval "$(echo "$c" | cut -d '=' -f2)"
+    done
 }

--- a/pdc/sh/init/setup.sh
+++ b/pdc/sh/init/setup.sh
@@ -28,9 +28,6 @@ function pdcdef_setup_create_variables() {
     # Default .yml
     pdcdef_create_variables "settings.yml"
 
-    # User .yml
-    [ -f "${pdcyml_settings_path_install}/pdc.yml" ] && pdcdef_create_variables "${pdcyml_settings_path_install}/pdc.yml"
-
     # Plugins .yml
     if [ -d "${pdcyml_settings_path_plugins}" ]; then
         for entry in ${pdcyml_settings_path_plugins}/*; do
@@ -40,6 +37,9 @@ function pdcdef_setup_create_variables() {
             pdcdef_create_variables "${entry}/plugin.yml"
         done
     fi
+
+    # User .yml
+    [ -f "${pdcyml_settings_path_install}/pdc.yml" ] && pdcdef_create_variables "${pdcyml_settings_path_install}/pdc.yml"
 
     # Additional .yml
     for yaml_file in $pdcyml_yaml_files; do

--- a/pdc/sh/utils/yaml.sh
+++ b/pdc/sh/utils/yaml.sh
@@ -34,7 +34,36 @@ function pdcdef_create_variables() {
     printf "Loading settings...\n"
 
     local yaml_file="$1"
-    eval "$(parse_yaml $yaml_file pdcyml)"
+
+    local variables
+    local exclude
+    local settings
+
+    variables="$(parse_yaml "$yaml_file" pdcyml_)"
+    exclude="$(pdcdef_load_settings "$yaml_file" pdcyml_settings_exclude)"
+
+    for e in ${exclude[*]}; do
+        settings+=( $(echo "$variables" | sed "s/\b$e\b//g") )
+    done
+
+    eval "$variables"
 
     printf "Settings loaded!\n"
+}
+
+function pdcdef_load_settings() {
+    local yaml_file=$1
+    local settings_to_load=$2
+
+    local settings
+    local variables
+
+    variables="$(parse_yaml "$yaml_file" pdcyml_)"
+
+    for setting in $settings_to_load; do
+        settings+=( $(echo "$variables" | grep "^${setting}=") )
+        settings+=( $(echo "$variables" | grep "^${setting}+=") )
+    done
+
+    echo "${settings[@]}"
 }

--- a/samples/pdc.yml
+++ b/samples/pdc.yml
@@ -11,5 +11,8 @@ plugins:
     - git@git.com:user/project.git
     - path:://path/to/plugin
     - tarball::endpoint/to/tarbal.tar
-  pre_execute:
-    - echo "a pre-execute plugin script"
+
+execute:
+  - plugin plugin-name
+  - bash myFile.sh
+  - shell echo something


### PR DESCRIPTION
Refactory execute step, now using executors to run some commands. All executors is configurable, by user or plugin.

For default, only simple shell (sh, bash) are configured.
A specific command can be used, for python, ruby, etc, using shell executor

For plugins, now a executor will do this work. Any plugin can add an pendent execute command for user.